### PR TITLE
Make too close specter related a run-time parameter

### DIFF
--- a/src/main/application/schemas/doc.sd
+++ b/src/main/application/schemas/doc.sd
@@ -196,10 +196,11 @@ schema doc {
   rank-profile related-specter {
     inputs {
         query(specter_vector) tensor<float>(x[768])
+        query(specter_limit) : 0.8
     }
     first-phase {
       rank-score-drop-limit: 0.0
-      expression: if(closeness(specter_embedding) > 0.95, -1, closeness(specter_embedding))
+      expression: if(closeness(specter_embedding) > query(specter_limit), -1, closeness(specter_embedding))
     }
   }
 }


### PR DESCRIPTION
The CORD-19 is full of near or exact duplicates. Setting the drop limit to a run-time parameter instead for exploration. 

![Screenshot 2022-12-08 at 22 25 06](https://user-images.githubusercontent.com/20928528/206570655-2b0d73e3-2e87-4784-b599-f9468c2ec312.png)
